### PR TITLE
provider/aws: Default Autoscaling Schedule min/max/desired to zero

### DIFF
--- a/builtin/providers/aws/resource_aws_autoscaling_schedule.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_schedule.go
@@ -97,17 +97,9 @@ func resourceAwsAutoscalingScheduleCreate(d *schema.ResourceData, meta interface
 		params.Recurrence = aws.String(attr.(string))
 	}
 
-	if attr, ok := d.GetOk("min_size"); ok {
-		params.MinSize = aws.Int64(int64(attr.(int)))
-	}
-
-	if attr, ok := d.GetOk("max_size"); ok {
-		params.MaxSize = aws.Int64(int64(attr.(int)))
-	}
-
-	if attr, ok := d.GetOk("desired_capacity"); ok {
-		params.DesiredCapacity = aws.Int64(int64(attr.(int)))
-	}
+	params.MinSize = aws.Int64(int64(d.Get("min_size").(int)))
+	params.MaxSize = aws.Int64(int64(d.Get("max_size").(int)))
+	params.DesiredCapacity = aws.Int64(int64(d.Get("desired_capacity").(int)))
 
 	log.Printf("[INFO] Creating Autoscaling Scheduled Action: %s", d.Get("scheduled_action_name").(string))
 	_, err := autoscalingconn.PutScheduledUpdateGroupAction(params)

--- a/builtin/providers/aws/resource_aws_autoscaling_schedule_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_schedule_test.go
@@ -216,8 +216,8 @@ resource "aws_autoscaling_schedule" "foobar" {
     max_size = 0
     min_size = 0
     desired_capacity = 0
-    start_time = "2016-01-16T07:00:00Z"
-    end_time = "2016-01-16T13:00:00Z"
+    start_time = "2018-01-16T07:00:00Z"
+    end_time = "2018-01-16T13:00:00Z"
     autoscaling_group_name = "${aws_autoscaling_group.foobar.name}"
 }
 `)

--- a/website/source/docs/providers/aws/r/autoscaling_schedule.html.markdown
+++ b/website/source/docs/providers/aws/r/autoscaling_schedule.html.markdown
@@ -45,9 +45,11 @@ The following arguments are supported:
 * `end_time` - (Optional) The time for this action to end, in "YYYY-MM-DDThh:mm:ssZ" format in UTC/GMT only (for example, 2014-06-01T00:00:00Z ).
                           If you try to schedule your action in the past, Auto Scaling returns an error messag
 * `recurrence` - (Optional) The time when recurring future actions will start. Start time is specified by the user following the Unix cron syntax format. 
-* `min_size` - (Optional) The minimum size for the Auto Scaling group.
-* `max_size` - (Optional) The maximum size for the Auto Scaling group.
-* `desired_capacity` - (Optional) The number of EC2 instances that should be running in the group.
+* `min_size` - (Optional) The minimum size for the Auto Scaling group. Default
+0.
+* `max_size` - (Optional) The maximum size for the Auto Scaling group. Default
+0.
+* `desired_capacity` - (Optional) The number of EC2 instances that should be running in the group. Default 0.
 
 ~> **NOTE:** When `start_time` and `end_time` are specified with `recurrence` , they form the boundaries of when the recurring action will start and stop.
 


### PR DESCRIPTION
Allow min/max/desired zero values 
